### PR TITLE
добавил несколько примеров реализации пайплайна

### DIFF
--- a/concurrency/task_create_pipeline/examples/parallel/parallel_pipeline.go
+++ b/concurrency/task_create_pipeline/examples/parallel/parallel_pipeline.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type Job func(in <-chan int) <-chan int
+
+func InitPipelineData() <-chan int {
+	out := make(chan int)
+
+	go func() {
+		for i := range 10 {
+			out <- i
+		}
+		close(out)
+	}()
+
+	return out
+}
+
+func FirstPipelineJob(in <-chan int) <-chan int {
+	out := make(chan int)
+	wg := sync.WaitGroup{}
+
+	for i := range in {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Second)
+			// Тут непосредственно действие, которое совершаем над данныме во входном канале.
+			// При этом параллелим эти действия в отдельных горутинах.
+			out <- i * 2
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}
+
+func SecondPipelineJob(in <-chan int) <-chan int {
+	out := make(chan int)
+	wg := sync.WaitGroup{}
+
+	for i := range in {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Second)
+			// Тут непосредственно действие, которое совершаем над данныме во входном канале.
+			// При этом параллелим эти действия в отдельных горутинах.
+			out <- i + 1
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}
+
+func ThirdPipelineJob(in <-chan int) <-chan int {
+	out := make(chan int)
+	wg := sync.WaitGroup{}
+
+	for i := range in {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Second)
+			// Тут непосредственно действие, которое совершаем над данныме во входном канале.
+			// При этом параллелим эти действия в отдельных горутинах.
+			out <- i * 10
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}
+
+func main() {
+	start := time.Now()
+	defer func() {
+		fmt.Printf("Итоговое время работы: %s", time.Since(start))
+	}()
+
+	jobs := []Job{
+		Job(FirstPipelineJob),
+		Job(SecondPipelineJob),
+		Job(ThirdPipelineJob),
+	}
+
+	result := InitPipelineData()
+	for _, job := range jobs {
+		result = job(result)
+	}
+
+	for data := range result {
+		fmt.Printf("Результат после прохождения всех шагов пайплайна: %d\n", data)
+	}
+}

--- a/concurrency/task_create_pipeline/examples/sequence/sequence_pipeline.go
+++ b/concurrency/task_create_pipeline/examples/sequence/sequence_pipeline.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+type Job func(in <-chan int) <-chan int
+
+func InitPipelineData() <-chan int {
+	out := make(chan int)
+
+	go func() {
+		for i := range 10 {
+			out <- i
+		}
+		close(out)
+	}()
+
+	return out
+}
+
+func FirstPipelineJob(in <-chan int) <-chan int {
+	out := make(chan int)
+
+	go func() {
+		for i := range in {
+			time.Sleep(time.Second)
+			// Тут непосредственно действие, которое совершаем над данныме во входном канале.
+			// При этом параллелим эти действия в отдельных горутинах.
+			out <- i * 2
+		}
+		close(out)
+	}()
+
+	return out
+}
+
+func SecondPipelineJob(in <-chan int) <-chan int {
+	out := make(chan int)
+
+	go func() {
+		for i := range in {
+			time.Sleep(time.Second)
+			// Тут непосредственно действие, которое совершаем над данныме во входном канале.
+			// При этом параллелим эти действия в отдельных горутинах.
+			out <- i + 1
+		}
+		close(out)
+	}()
+
+	return out
+}
+
+func ThirdPipelineJob(in <-chan int) <-chan int {
+	out := make(chan int)
+
+	go func() {
+		for i := range in {
+			time.Sleep(time.Second)
+			// Тут непосредственно действие, которое совершаем над данныме во входном канале.
+			// При этом параллелим эти действия в отдельных горутинах.
+			out <- i * 10
+		}
+		close(out)
+	}()
+
+	return out
+}
+
+func main() {
+	start := time.Now()
+	defer func() {
+		fmt.Printf("Итоговое время работы: %s", time.Since(start))
+	}()
+
+	jobs := []Job{
+		Job(FirstPipelineJob),
+		Job(SecondPipelineJob),
+		Job(ThirdPipelineJob),
+	}
+
+	result := InitPipelineData()
+	for _, job := range jobs {
+		result = job(result)
+	}
+
+	for data := range result {
+		fmt.Printf("Результат после прохождения всех шагов пайплайна: %d\n", data)
+	}
+}


### PR DESCRIPTION
Тут два примера: 
1) параллельное выполнение действий на каждом шаге. Шаг - это Job. 
2) последовательное выполнение действий на каждом шаге.

Итоговое время выполнения выводится в main, в пайплайн запускаются 10 интов, на каждом шаге получается 10 действий. Каждое действие - 1 секунда.
По итогу (результаты могут отличаться на разных компьютерах):
- для 1 кейса выполнение займет ±3 секунды
- для 2 кейса выполнения займет ±12 секунд
